### PR TITLE
generate .crt too

### DIFF
--- a/generate_ssl.sh
+++ b/generate_ssl.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-openssl req -newkey rsa:4096 -nodes -keyout cert/authserver/server.key -x509 -subj '/CN=localhost' -days 7300 -out cert/authserver/server.crt
-openssl req -newkey rsa:4096 -nodes -keyout cert/sessionserver/server.key -x509 -subj '/CN=localhost' -days 7300 -out cert/sessionserver/server.crtopenssl genrsa -out cert/apiserver/server.key 4096 -x509 -out cert/apiserver/server.crt
-openssl req -newkey rsa:4096 -nodes -keyout cert/apiserver/server.key -x509 -subj '/CN=localhost' -days 7300 -out cert/apiserver/server.crt
+openssl req -newkey rsa:4096 -nodes -keyout cert/authserver/certificate.key -x509 -subj '/CN=localhost' -days 7300 -out cert/authserver/certificate.crt
+openssl req -newkey rsa:4096 -nodes -keyout cert/sessionserver/certificate.key -x509 -subj '/CN=localhost' -days 7300 -out cert/sessionserver/certificate.crt
+openssl req -newkey rsa:4096 -nodes -keyout cert/apiserver/certificate.key -x509 -subj '/CN=localhost' -days 7300 -out cert/apiserver/certificate.crt
 
 echo -e " The Certificates and Keys have been generated!"
 cd ..

--- a/generate_ssl.sh
+++ b/generate_ssl.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-openssl genrsa -out cert/authserver/server.key 4096
-openssl genrsa -out cert/sessionserver/server.key 4096
-openssl genrsa -out cert/apiserver/server.key 4096
+openssl req -newkey rsa:4096 -nodes -keyout cert/authserver/server.key -x509 -subj '/CN=localhost' -days 7300 -out cert/authserver/server.crt
+openssl req -newkey rsa:4096 -nodes -keyout cert/sessionserver/server.key -x509 -subj '/CN=localhost' -days 7300 -out cert/sessionserver/server.crtopenssl genrsa -out cert/apiserver/server.key 4096 -x509 -out cert/apiserver/server.crt
+openssl req -newkey rsa:4096 -nodes -keyout cert/apiserver/server.key -x509 -subj '/CN=localhost' -days 7300 -out cert/apiserver/server.crt
 
 echo -e " The Certificates and Keys have been generated!"
 cd ..


### PR DESCRIPTION
the generate_ssl.sh script was only generating the .key files, not the .crt too.  Modified it to create both. There are probably other ways of doing this too.